### PR TITLE
Add the ability to mount the source dir (and other stuff)

### DIFF
--- a/Customfile
+++ b/Customfile
@@ -1,0 +1,16 @@
+
+if args.key?('custom')
+    custom = args['custom']
+
+    if custom.key?('source_dir')
+        vvv_dir = args['local_dir']
+        source_dir = File.expand_path(custom['source_dir'], vvv_dir)
+
+        if File.directory?(source_dir)
+            vm_source_dir = File.join('/srv/sources/', site)
+
+            # TODO: do not mount source_dir if it is a subdirectory of vvv_dir (it's not necessary)
+            config.vm.synced_folder source_dir, vm_source_dir, :mount_options => [ "dmode=775", "fmode=774" ]
+        end
+    end
+end

--- a/provision/vvv-custom.sh
+++ b/provision/vvv-custom.sh
@@ -1,0 +1,18 @@
+SOURCE_DIR="/srv/sources/$SITE"
+
+if [ -d "$SOURCE_DIR" ]; then
+    SRC_WP_PLUGINS=`cat ${VVV_CONFIG} | shyaml get-values sites.${SITE_ESCAPED}.custom.source_dir_wp_plugins 2> /dev/null`
+
+    for p in $SRC_WP_PLUGINS; do
+        BASE_NAME=`basename $p`
+        LINK_DEST="$VVV_PATH_TO_SITE/public_html/wp-content/plugins/$BASE_NAME"
+
+        if [ -L "$LINK_DEST" ]; then
+            rm -f "$LINK_DEST"
+        fi
+
+        if [ ! -e "$LINK_DEST" ]; then
+            ln -s "$SOURCE_DIR/$p" "$LINK_DEST"
+        fi
+    done
+fi

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -53,3 +53,5 @@ fi
 
 cp -f "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf.tmpl" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
 sed -i "s#{{DOMAINS_HERE}}#${DOMAINS}#" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
+
+source "$VVV_PATH_TO_SITE/provision/vvv-custom.sh"


### PR DESCRIPTION
This PR adds:

- A custom script that takes care of mounting the source dir, for cases when the source is outside of the `www/site` dir, making it available to provision scripts.

   Obviously, executing this custom script, requires that `allow_customfile: true` is set in the `vvv-custom.yml` file for the given site.
- A small custom script that takes care of symlinking possible WP plugins from the source dir automatically, depending on the configuration var `source_dir_wp_plugins`.

- - - 

The following `vvv-custom.yml` illustrates how to configure a site such as this:

* Source dir is `~/src/BusinessDirectoryPlugin/`
* VVV dir (with `public_html`, etc.) lives under the main source dir in  `~/src/BusinessDirectoryPlugin/_vvv`
* Scripts should automatically create a symlink of `<source dir>/business-directory-plugin` and `<source dir>/premium-modules/business-directory-attachments` inside the `wp-content/plugins` dir for this site inside the VM.

```yaml
---
sites:
  businessdirectory:
    local_dir: /Users/jorge/src/BusinessDirectoryPlugin/_vvv/
    hosts:
      - businessdirectory.dev
    allow_customfile: true
    custom:
      source_dir: ../
      source_dir_wp_plugins:
        - business-directory-plugin
        - premium-modules/business-directory-attachments
```

- - -

I have several questions, even if we ignore the not-so-great quality of my code 🦆:

- Should all of this (such as the symlink information) be part of VVV's configuration for the site, or should we allow our scripts to obtain some information from the source dir itself to gather this info?
- Should we allow execution of custom scripts that are part of the source dir itself?

I'd like to keep things as they are (if it were up to me) since it means source code and VVV configuration are separate and customizable (someone might not want to symlink everything or something like that).